### PR TITLE
Remove old CVMFS_SERVERs

### DIFF
--- a/config-egi.egi.eu.conf
+++ b/config-egi.egi.eu.conf
@@ -26,7 +26,7 @@ fi
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
     if [ "$CVMFS_CLIENT_PROFILE" != "custom" ]; then
         CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
     fi

--- a/config-egi.egi.eu.conf
+++ b/config-egi.egi.eu.conf
@@ -26,7 +26,7 @@ fi
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    CVMFS_SERVER_URL="http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
+    http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@
     if [ "$CVMFS_CLIENT_PROFILE" != "custom" ]; then
         CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
     fi

--- a/config-egi.egi.eu.conf
+++ b/config-egi.egi.eu.conf
@@ -26,7 +26,7 @@ fi
 if [ "$CVMFS_USE_CDN" = "yes" ]; then
     CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
-    http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
     if [ "$CVMFS_CLIENT_PROFILE" != "custom" ]; then
         CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
     fi


### PR DESCRIPTION
We've noticed that cvmfs-egi.gridpp.rl.ac.uk and cvmfsrep.grid.sinica.edu.tw are inaccessible, so we recommend deleting these two cvmfs repos.

There is no additional impact other than a warning message, but since they can sometimes cause repository failures, we feel it is appropriate to remove them.
